### PR TITLE
Fixed <outputDir> configuration problem

### DIFF
--- a/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPDownloadMojo.java
+++ b/gp-maven-plugin/src/main/java/com/ibm/g11n/pipeline/maven/GPDownloadMojo.java
@@ -153,7 +153,7 @@ public class GPDownloadMojo extends GPBaseMojo {
 
         switch (bundleLayout) {
         case LANGUAGE_SUFFIX: {
-            File dir = (new File(outputDir, relPath)).getParentFile();
+            File dir = (new File(outBaseDir, relPath)).getParentFile();
             int idx = srcFileName.lastIndexOf('.');
             String tgtName = null;
             if (idx < 0) {
@@ -166,13 +166,13 @@ public class GPDownloadMojo extends GPBaseMojo {
             break;
         }
         case LANGUAGE_SUBDIR: {
-            File dir = (new File(outputDir, relPath)).getParentFile();
+            File dir = (new File(outBaseDir, relPath)).getParentFile();
             File langSubDir = new File(dir, getLanguageId(language, langIdStyle, langMap));
             outputFile = new File(langSubDir, srcFileName);
             break;
         }
         case LANGUAGE_DIR:
-            File dir = (new File(outputDir, relPath)).getParentFile().getParentFile();
+            File dir = (new File(outBaseDir, relPath)).getParentFile().getParentFile();
             File langDir = new File(dir, getLanguageId(language, langIdStyle, langMap));
             outputFile = new File(langDir, srcFileName);
             break;


### PR DESCRIPTION
<bundleSet><outputDir> configuration should override the default output
root directory for the bundle set. When the implementation was updated
to handle bundleSet specific setting, this setting was not properly
implemented. Fixes #16.