### PR TITLE
Misc. changes for gp-java-tools 1.1.3 release

### DIFF
--- a/gp-cli/pom.xml
+++ b/gp-cli/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.2</version>
+			<version>1.1.3</version>
 		</dependency>
 
 		<dependency>

--- a/gp-cli/pom.xml
+++ b/gp-cli/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.0</version>
+			<version>1.1.2</version>
 		</dependency>
 
 		<dependency>

--- a/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ExportCmd.java
+++ b/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ExportCmd.java
@@ -29,6 +29,7 @@ import com.ibm.g11n.pipeline.client.ServiceException;
 import com.ibm.g11n.pipeline.resfilter.Bundle;
 import com.ibm.g11n.pipeline.resfilter.ResourceFilter;
 import com.ibm.g11n.pipeline.resfilter.ResourceFilterFactory;
+import com.ibm.g11n.pipeline.resfilter.ResourceString;
 import com.ibm.g11n.pipeline.resfilter.ResourceType;
 
 /**
@@ -89,7 +90,9 @@ final class ExportCmd extends BundleCmd {
                     if (seqNum != null) {
                         sequenceNumber = seqNum.intValue();
                     }
-                    bundle.addResourceString(key, resVal, sequenceNumber);
+                    ResourceString resString = new ResourceString(key, resVal,
+                            sequenceNumber, data.getNotes());
+                    bundle.addResourceString(resString);
                 }
             }
         } catch (ServiceException e) {

--- a/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ImportCmd.java
+++ b/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ImportCmd.java
@@ -71,6 +71,7 @@ final class ImportCmd extends BundleCmd {
                 if (seqNum >= 0) {
                     resEntryData.setSequenceNumber(Integer.valueOf(seqNum));
                 }
+                resEntryData.setNotes(resString.getNotes());
                 resEntries.put(resString.getKey(), resEntryData);
             }
         } catch (IOException e) {

--- a/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ResourceTypeConverter.java
+++ b/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ResourceTypeConverter.java
@@ -1,5 +1,5 @@
 /*  
- * Copyright IBM Corp. 2015
+ * Copyright IBM Corp. 2015, 2016
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import com.ibm.g11n.pipeline.resfilter.ResourceType;
  * 
  * @author Yoshito Umaoka
  */
-class ResourceTypeConverter implements IStringConverter<ResourceType>{
+public class ResourceTypeConverter implements IStringConverter<ResourceType>{
 
     @Override
     public ResourceType convert(String type) {

--- a/gp-maven-plugin.md
+++ b/gp-maven-plugin.md
@@ -274,9 +274,9 @@ If you have properties file `src/resources/com/ibm/example/MyStrings.properties`
 instead of `target/classes/com/ibm/example/MyStrings_pt_BR.properties`
 
 Note: The language ID separator used in the mapping should be '-' (Hyphen) for both,
-even you want expect translated file name (or path) to use '_'. So, in above example,
-do not specify `<zh-Hant>zh_TW</zh-Hant>` even you want `MyStrings_zh_TW.properties`
-as the output file name. The language suffix style is configured by `<languageIdStyle>`.
+even you want translated file name (or path) to use '_' for the language part. In the example
+above, do not specify `<zh-Hant>zh_TW</zh-Hant>` even you want `MyStrings_zh_TW.properties`
+as the output file name. The language ID style is configured by `<languageIdStyle>`.
 
 
 ### Translated JSON Files in Language Directories

--- a/gp-maven-plugin/pom.xml
+++ b/gp-maven-plugin/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>

--- a/gp-maven-plugin/pom.xml
+++ b/gp-maven-plugin/pom.xml
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>
 			<artifactId>gp-java-client</artifactId>
-			<version>1.1.2</version>
+			<version>1.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.g11n.pipeline</groupId>

--- a/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/Bundle.java
+++ b/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/Bundle.java
@@ -59,7 +59,7 @@ public final class Bundle {
     
     public void addNotes(List<String> inputNotes) {
         for (String note : inputNotes) {
-            notes.add(note);
+            addNote(note);
         }
     }
 


### PR DESCRIPTION
A bunch of small changes for official gp-java-tools release 1.1.3.

- Updated gp-java-client dependency from 1.1.1 to 1.1.3.
- Fixed gp-res-filter test failure issue.
- CLI import format type resolution problem (jcommand could not resolve enum mapping because ResourceTypeConverter was package private.)
- CLI import/export to handle new notes field.
- Maven upload goal to include notes field values.
- Editorial fixe in the maven plugin user guide.