### PR TITLE
Implemented gp-cli import as reviewed

### DIFF
--- a/gp-cli.md
+++ b/gp-cli.md
@@ -322,7 +322,7 @@ java -jar gp-cli.jar create -b com.ibm.example.MyBundle -l en -j mycreds.json
 ```
 
 2\. Import the English(en) resource bundle contents to *MyBundle*. The resource bundle
-file in this example is a Java properties fiel - MyBundle.properties
+file in this example is a Java properties file - MyBundle.properties
 ```
 java -jar gp-cli.jar import -b com.ibm.example.MyBundle -l en -t JAVA -f MyBundle.properties -j mycreds.json
 ```
@@ -330,9 +330,10 @@ At this point, the bundle *com.ibm.example.MyBundle* in the Globalization
 Pipeline service instance contains only English resource strings.
 
 3\. Import the corresponding translated version. In this example, the operation
-below imports French(fr) translation from MyBundle_fr.properties.
+below imports French(fr) translation from MyBundle_fr.properties and marks
+resource strings as already reviewed (-r).
 ```
-java -jar gp-cli.jar import -b com.ibm.example.MyBundle -l fr -t JAVA -f MyBundle_fr.properties -j mycreds.json
+java -jar gp-cli.jar import -b com.ibm.example.MyBundle -l fr -t JAVA -f MyBundle_fr.properties -j mycreds.json -r
 ```
 This operation automatically adds French to the bundle *com.ibm.example.MyBundle*.
 

--- a/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ImportCmd.java
+++ b/gp-cli/src/main/java/com/ibm/g11n/pipeline/tools/cli/ImportCmd.java
@@ -57,6 +57,11 @@ final class ImportCmd extends BundleCmd {
             required = true)
     private String fileName;
 
+    @Parameter(
+            names = {"-r", "--reviewed"},
+            description = "Mark imported resource strings as reviewed")
+    private boolean asReviewed = false;
+
     @Override
     protected void _execute() {
         Map<String, NewResourceEntryData> resEntries = null;
@@ -72,6 +77,9 @@ final class ImportCmd extends BundleCmd {
                     resEntryData.setSequenceNumber(Integer.valueOf(seqNum));
                 }
                 resEntryData.setNotes(resString.getNotes());
+                if (asReviewed) {
+                    resEntryData.setReviewed(Boolean.TRUE);
+                }
                 resEntries.put(resString.getKey(), resEntryData);
             }
         } catch (IOException e) {


### PR DESCRIPTION
Added a new boolean option -r in GP CLI import command. When the option
is specified, all resource entries from the specified file will be
marked as reviewed. Fixes #34.