### PR TITLE
Pass project build dir to maven invoker plugin hook

### DIFF
--- a/gp-maven-plugin/pom.xml
+++ b/gp-maven-plugin/pom.xml
@@ -139,6 +139,9 @@
 							<pomIncludes>
 								<pomInclude>*/pom.xml</pomInclude>
 							</pomIncludes>
+							<scriptVariables>
+								<bldDir>${project.build.directory}</bldDir>
+							</scriptVariables>
 							<preBuildHookScript>setup</preBuildHookScript>
 							<postBuildHookScript>verify</postBuildHookScript>
 							<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>

--- a/gp-maven-plugin/src/it/t1-basic-upload-fail/setup.groovy
+++ b/gp-maven-plugin/src/it/t1-basic-upload-fail/setup.groovy
@@ -21,7 +21,7 @@ import java.util.regex.*
 
 try {
 	println "Set up for basic upload fail test"
-    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile("target/it/t1-basic-upload-fail", "setup.properties")
+    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile(bldDir + "/it/t1-basic-upload-fail", "setup.properties")
       
 } catch( Throwable t ) {
     t.printStackTrace()

--- a/gp-maven-plugin/src/it/t2-basic-upload-success/setup.groovy
+++ b/gp-maven-plugin/src/it/t2-basic-upload-success/setup.groovy
@@ -22,7 +22,7 @@ import java.util.regex.*
 
 try {
 	println "Set up for basic upload success test"
-    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile("target/it/t2-basic-upload-success", "setup.properties")
+    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile(bldDir + "/it/t2-basic-upload-success", "setup.properties")
 } catch( Throwable t ) {
     t.printStackTrace()
     return false

--- a/gp-maven-plugin/src/it/t2-basic-upload-success/verify.groovy
+++ b/gp-maven-plugin/src/it/t2-basic-upload-success/verify.groovy
@@ -23,7 +23,7 @@ import com.ibm.g11n.pipeline.client.*
 
 try {
     println "verifying that upload succeeded"
-    String location = "target/it/t2-basic-upload-success";
+    String location = bldDir + "/it/t2-basic-upload-success";
     String propfile = "setup.properties"
     def propertyMap = ITTools.loadProperties(location, propfile);
     Credentials creds = ITTools.getCredentials(location, propfile);

--- a/gp-maven-plugin/src/it/t3-basic-download-fail/setup.groovy
+++ b/gp-maven-plugin/src/it/t3-basic-download-fail/setup.groovy
@@ -21,7 +21,7 @@ import java.util.regex.*
 
 try {
     println "setup for basic download fail test"
-    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile("target/it/t3-basic-download-fail", "setup.properties")  
+    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile(bldDir + "/it/t3-basic-download-fail", "setup.properties")  
 } catch( Throwable t ) {
     t.printStackTrace()
     return false

--- a/gp-maven-plugin/src/it/t4-basic-download-success/setup.groovy
+++ b/gp-maven-plugin/src/it/t4-basic-download-success/setup.groovy
@@ -21,7 +21,7 @@ import java.util.regex.*
 
 try {
     println "setup for basic download success test"
-    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile("target/it/t4-basic-download-success", "setup.properties")     
+    com.ibm.g11n.pipeline.maven.ITTools.createCredentialsFile(bldDir + "/it/t4-basic-download-success", "setup.properties")     
 } catch( Throwable t ) {
     t.printStackTrace()
     return false

--- a/gp-maven-plugin/src/it/t4-basic-download-success/verify.groovy
+++ b/gp-maven-plugin/src/it/t4-basic-download-success/verify.groovy
@@ -23,7 +23,7 @@ import com.google.gson.*
 
 try {
     println "verifying that download happened successfully"
-    String location="target/it/t4-basic-download-success"
+    String location = bldDir + "/it/t4-basic-download-success"
     String targetLocation = location + "/target/classes/com/bundle1"
     def dir = new File(targetLocation)
     int filecount = 0


### PR DESCRIPTION
gp-maven-plugin integration tests are failing if they are invoked from
the parent project directory because build output directory is hardcoded
in the groovy hook scripts. Use <scriptVariables> to pass the project
build directory to the hook scripts, so the test goal is properly
invoked from any directories.