### PR TITLE
Fixed a backward compatibility issue in JSON filter

### DIFF
--- a/gp-cli/.settings/org.eclipse.core.resources.prefs
+++ b/gp-cli/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,4 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
 encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/gp-maven-plugin/.settings/org.eclipse.core.resources.prefs
+++ b/gp-maven-plugin/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,4 @@
 eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
 encoding//src/test/java=UTF-8
+encoding/<project>=UTF-8

--- a/gp-res-filter/.settings/org.eclipse.core.resources.prefs
+++ b/gp-res-filter/.settings/org.eclipse.core.resources.prefs
@@ -2,3 +2,4 @@ eclipse.preferences.version=1
 encoding//src/main/java=UTF-8
 encoding//src/test/java=UTF-8
 encoding//src/test/resource/resfilter/ios/write-output.strings=UTF-8
+encoding/<project>=UTF-8

--- a/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/GlobalizeJsResource.java
+++ b/gp-res-filter/src/main/java/com/ibm/g11n/pipeline/resfilter/GlobalizeJsResource.java
@@ -77,7 +77,7 @@ public class GlobalizeJsResource extends JsonResource {
             String key = entry.getKey();
             JsonElement value = entry.getValue();
             if (value.isJsonObject()) {
-                sequenceNum = addBundleStrings(value.getAsJsonObject(), modifiedKeyPrefix(keyPrefix, key, "$."), bundle,
+                sequenceNum = addBundleStrings(value.getAsJsonObject(), encodeResourceKey(keyPrefix, key, false), bundle,
                         sequenceNum);
             } else if (value.isJsonArray()) {
                 JsonArray ar = value.getAsJsonArray();
@@ -95,12 +95,12 @@ public class GlobalizeJsResource extends JsonResource {
                     }
                 }
                 sequenceNum++;
-                bundle.addResourceString(modifiedKeyPrefix(keyPrefix, key, ""), sb.toString(), sequenceNum);
+                bundle.addResourceString(encodeResourceKey(keyPrefix, key, true), sb.toString(), sequenceNum);
             } else if (!value.isJsonPrimitive() || !value.getAsJsonPrimitive().isString()) {
                 throw new IllegalResourceFormatException("The value of JSON element " + key + " is not a string.");
             } else {
                 sequenceNum++;
-                bundle.addResourceString(modifiedKeyPrefix(keyPrefix, key, ""), value.getAsString(), sequenceNum);
+                bundle.addResourceString(encodeResourceKey(keyPrefix, key, true), value.getAsString(), sequenceNum);
             }
         }
         return sequenceNum;

--- a/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/JsonResourceTest.java
+++ b/gp-res-filter/src/test/java/com/ibm/g11n/pipeline/resfilter/JsonResourceTest.java
@@ -69,9 +69,14 @@ public class JsonResourceTest {
         lst.add(new ResourceString("$.colors[1]", "blue", 20));
         lst.add(new ResourceString("$.colors[2]", "yellow", 21));
         lst.add(new ResourceString("$.colors[3]", "orange", 22));
-        lst.add(new ResourceString("['frog[\\u00272\\u0027]']", "Red-eyed Tree Frog", 23));
-        lst.add(new ResourceString("['owl[3]']", "Great Horned Owl", 24));
-        lst.add(new ResourceString("some_text", "Just a plain old string", 25));
+        lst.add(new ResourceString("some_text", "Just a plain old string", 23));
+        lst.add(new ResourceString("another.text", "Another plain old string", 24));
+        lst.add(new ResourceString("frog['2']", "Red-eyed Tree Frog", 25));
+        lst.add(new ResourceString("owl[3]", "Great Horned Owl", 26));
+        lst.add(new ResourceString("$['$.xxx']", "Looks like JSONPATH, but actually plain old string", 27));
+        lst.add(new ResourceString("$['$.']", "Looks like JSONPATH prefix, but actually plain old string", 28));
+        lst.add(new ResourceString("$abc", "Starts with JSONPATH root char, but just a string", 29));
+        lst.add(new ResourceString("$['ibm.com']['g11n.pipeline.title']", "Globalization Pipeline", 30));
 
         Collections.sort(lst, new ResourceStringComparator());
         EXPECTED_INPUT_RES_LIST = lst;
@@ -103,9 +108,14 @@ public class JsonResourceTest {
         WRITE_BUNDLE.addResourceString("$.colors[1]", "blue - XL", 20);
         WRITE_BUNDLE.addResourceString("$.colors[2]", "yellow - XL", 21);
         WRITE_BUNDLE.addResourceString("$.colors[3]", "orange - XL", 22);
-        WRITE_BUNDLE.addResourceString("['frog[\\u00272\\u0027]']", "Red-eyed Tree Frog - XL", 23);
-        WRITE_BUNDLE.addResourceString("['owl[3]']", "Great Horned Owl - XL", 24);
-        WRITE_BUNDLE.addResourceString("some_text", "Just a plain old string - XL", 25);
+        WRITE_BUNDLE.addResourceString("some_text", "Just a plain old string - XL", 23);
+        WRITE_BUNDLE.addResourceString("another.text", "Another plain old string - XL", 24);
+        WRITE_BUNDLE.addResourceString("frog['2']", "Red-eyed Tree Frog - XL", 25);
+        WRITE_BUNDLE.addResourceString("owl[3]", "Great Horned Owl - XL", 26);
+        WRITE_BUNDLE.addResourceString("$['$.xxx']", "Looks like JSONPATH, but actually plain old string - XL", 27);
+        WRITE_BUNDLE.addResourceString("$['$.']", "Looks like JSONPATH prefix, but actually plain old string - XL", 28);
+        WRITE_BUNDLE.addResourceString("$abc", "Starts with JSONPATH root char, but just a string - XL", 29);
+        WRITE_BUNDLE.addResourceString("$['ibm.com']['g11n.pipeline.title']", "Globalization Pipeline - XL", 30);
     }
 
     private static final JsonResource res = new JsonResource();

--- a/gp-res-filter/src/test/resource/resfilter/json/input.json
+++ b/gp-res-filter/src/test/resource/resfilter/json/input.json
@@ -1,14 +1,14 @@
 {
     "bears": {
-    	"grizzly": {
-    	    "brown": "Brown Bear",
-    	    "black": "Black Bear"
-    	},
+        "grizzly": {
+            "brown": "Brown Bear",
+            "black": "Black Bear"
+        },
         "white": "Polar Bear"
     },
     "countries": [ 
-    	{ "Europe": [ "Germany", "Italy", "France", "Spain" ]},
-    	{ "Asia": [ "China", "Japan", "India"] },
+        { "Europe": [ "Germany", "Italy", "France", "Spain" ]},
+        { "Asia": [ "China", "Japan", "India"] },
         { "Americas": {
             "S. America": [ "Brazil", "Venezuela"],
             "N. America": [ "United States [USA]", "Canada", "Mexico"]
@@ -17,7 +17,14 @@
         { "Africa": [ "Egypt", "Somalia", "S. Africa" ]}
     ],
     "colors": ["red", "blue", "yellow", "orange" ],
+    "some_text": "Just a plain old string",
+    "another.text": "Another plain old string",
     "frog['2']": "Red-eyed Tree Frog",
     "owl[3]": "Great Horned Owl",
-    "some_text": "Just a plain old string"
+    "$.xxx": "Looks like JSONPATH, but actually plain old string",
+    "$.": "Looks like JSONPATH prefix, but actually plain old string",
+    "$abc": "Starts with JSONPATH root char, but just a string",
+    "ibm.com": {
+        "g11n.pipeline.title": "Globalization Pipeline"
+    }
 }

--- a/gp-res-filter/src/test/resource/resfilter/json/write-output.json
+++ b/gp-res-filter/src/test/resource/resfilter/json/write-output.json
@@ -49,7 +49,14 @@
     "yellow - XL",
     "orange - XL"
   ],
+  "some_text": "Just a plain old string - XL",
+  "another.text": "Another plain old string - XL",
   "frog['2']": "Red-eyed Tree Frog - XL",
   "owl[3]": "Great Horned Owl - XL",
-  "some_text": "Just a plain old string - XL"
+  "$.xxx": "Looks like JSONPATH, but actually plain old string - XL",
+  "$.": "Looks like JSONPATH prefix, but actually plain old string - XL",
+  "$abc": "Starts with JSONPATH root char, but just a string - XL",
+  "ibm.com": {
+    "g11n.pipeline.title": "Globalization Pipeline - XL"
+  }
 }


### PR DESCRIPTION
The previous change in JSON filter forced plain top-level string object
keys including dot character encoded into jsonpath. This intorduced a
compatibility issue with existing bundles. We use jsonpath when we need
to flatten keys for nested objects and arrays, but we should keep top
level string object keys unchanged unless it collides with jsonpath.
This PR uopdated the code to skip jsonpath encoding  unless top level
string key does not start with "$." or "$[".

Also updated project's default encodings in Eclipse project files to
UTF-8.

Fixes #75.